### PR TITLE
Adjust usage text with correct default log path

### DIFF
--- a/chiaharvestgraph.c
+++ b/chiaharvestgraph.c
@@ -493,7 +493,7 @@ int main(int argc, char *argv[])
 
 	if (argc != 2)
 	{
-		fprintf( stderr, "Usage: %s ~/.chia/mainet/log\n", argv[0] );
+		fprintf( stderr, "Usage: %s ~/.chia/mainnet/log\n", argv[0] );
 		exit( 1 );
 	}
 	else


### PR DESCRIPTION
Tiny change which suggests default log path is provided (missing an n) and may simplify initial run for some folks.