### PR TITLE
Update chiaharvestgraph.c - fix for other forks

### DIFF
--- a/chiaharvestgraph.c
+++ b/chiaharvestgraph.c
@@ -288,7 +288,7 @@ static void analyze_line(const char* line, ssize_t length)
 			const int num = sscanf
 			(
 				line,
-				"%04d-%02d-%02dT%02d:%02d:%f harvester %[^.].harvester.harvester: INFO "
+				"%04d-%02d-%02dT%02d:%02d:%f harvester %[^.].harvester.harveste%*[^:]: INFO "
 				"%d plots were eligible for farming %s Found %d proofs. Time: %f s. Total %d plots",
 				&year,
 				&month,


### PR DESCRIPTION
The program does not work with forks with a shorter name than "chia" (like TAD). There is extra space at the end of service name:
```2021-09-09T08:06:41.724 harvester tad.harvester.harvester : INFO```
This PR fixes this bug.